### PR TITLE
Updated MacClam.sh for macOS Big Sur and Monterey

### DIFF
--- a/MacClam.sh
+++ b/MacClam.sh
@@ -760,12 +760,12 @@ BEGIN {
         sub(/OK$/,g"OK"n,file)
         printf "%s...%s\r",dir,file
     }
-    fflush;next
+    flush;next
 }
 /SelfCheck: Database status OK./ {
     filename()
     printf e"K%."tmax"s\r",$0
-    fflush;next
+    flush;next
 }
 /^==> / {
     if (pf) {
@@ -775,7 +775,7 @@ BEGIN {
         printf c "%."tmax"s\n" n,f=$0
         pf=1
     }
-    fflush;next
+    flush;next
 }
 !/^ *$/ {
     sub(/ERROR/,r"ERROR"n)


### PR DESCRIPTION
Lines 763, 768, and 778 no longer work with macOS 11 and newer. Replacing depreciated 'fflush' with 'flush'

Works and shows the proper output in the terminal instead of giving the syntax error below:

------------------
 Current Activity
------------------

You can press Control-C to stop viewing activity.  Scanning services will continue running.

awk: cmd. line:44:     fflush;next
awk: cmd. line:44:           ^ syntax error
awk: cmd. line:49:     fflush;next
awk: cmd. line:49:           ^ syntax error
awk: cmd. line:59:     fflush;next
awk: cmd. line:59:           ^ syntax error


Stopped showing activity.  Scan services continue to run.
Run the script again at any time to view activity.
Run 'MacClam.sh help' for more commands.